### PR TITLE
manually install pyecharts_snapshot

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -8,6 +8,7 @@ pip install lxml
 pip install matplotlib
 pip install pandas
 pip install pyecharts
+pip install pyecharts-snapshot
 pip install PyMySQL
 
 python ./SimpleMode/autoRun.py


### PR DESCRIPTION
issue refer to https://github.com/pyecharts/pyecharts/issues/750

我用python3.7, windows10 跑完了案例，会报错 import 找不到 pyecharts-snapshot

手动安装后`pip install pyecharts-snapshot`就可以正常使用了

谢谢提供有趣的代码～